### PR TITLE
more flexible threads plots

### DIFF
--- a/src/cdsg_plot/qcdb_plot.py
+++ b/src/cdsg_plot/qcdb_plot.py
@@ -72,25 +72,25 @@ def expand_saveas(
 
 def segment_color(argcolor, saptcolor):
     """Find appropriate color expression between overall color directive
-    *argcolor* and particular color availibility *rxncolor*.
+    *argcolor* and particular color availibility *saptcolor*.
 
     """
     import matplotlib
 
-    # validate any sapt color
-    if saptcolor is not None:
-        if saptcolor < 0.0 or saptcolor > 1.0:
-            saptcolor = None
-
+    # May 2024 change: set outer (not rxn) color arg to "sapt" or "rgb" to get sapt interpretation.
+    #   Default None for outer color arg will no longer route to sapt interpretation.
     if argcolor is None:
         # no color argument, so take from rxn
-        if rxncolor is None:
+        if saptcolor is None:
             clr = "grey"
-        elif saptcolor is not None:
-            clr = matplotlib.cm.jet(saptcolor)
         else:
-            clr = rxncolor
+            clr = saptcolor
     elif argcolor == "sapt":
+        # validate any sapt color
+        if saptcolor is not None:
+            if saptcolor < 0.0 or saptcolor > 1.0:
+                saptcolor = None
+
         # sapt color from rxn if available
         if saptcolor is not None:
             clr = matplotlib.cm.jet(saptcolor)
@@ -595,6 +595,8 @@ def threads(
     color=None,
     title="",
     xlimit=4.0,
+    xlimitleft=None,
+    xticks=None,
     mae=None,
     mape=None,
     mousetext=None,
@@ -640,18 +642,24 @@ def threads(
             [positions[weft] - lenS - gapT, positions[weft + 1] + lenS + gapT, None]
         )
     posnM = []
+    if xlimitleft is None:
+        xlimitleft = -1 * xlimit
+    xrange = xlimit - xlimitleft
+    if xticks is None:
+        xticks = [xlimitleft + 0.25 * xrange, xlimitleft + 0.375 * xrange,
+                  xlimitleft + 0.5 * xrange, xlimitleft + 0.625 * xrange, xlimitleft + 0.75 * xrange]
 
     # initialize plot
     fht = Nweft * 0.8
     # fig, ax = plt.subplots(figsize=(12, fht))
     fig, ax = plt.subplots(figsize=(11, fht))
     plt.subplots_adjust(left=0.01, right=0.99, hspace=0.3)
-    plt.xlim([-xlimit, xlimit])
+    plt.xlim([xlimitleft, xlimit])
     plt.ylim([-1 * Nweft - 1, 0])
     plt.yticks([])
     ax.set_frame_on(False)
     if labeled:
-        ax.set_xticks([-0.5 * xlimit, -0.25 * xlimit, 0.0, 0.25 * xlimit, 0.5 * xlimit])
+        ax.set_xticks(xticks)
     else:
         ax.set_xticks([])
     for tick in ax.xaxis.get_major_ticks():
@@ -661,7 +669,7 @@ def threads(
     # label plot and tiers
     if labeled:
         ax.text(
-            -0.9 * xlimit,
+            xlimitleft + 0.05 * xrange,
             -0.25,
             title,
             verticalalignment="bottom",
@@ -672,7 +680,7 @@ def threads(
         )
         for weft in labels:
             ax.text(
-                -0.9 * xlimit,
+                xlimitleft + 0.05 * xrange,
                 -(1.2 + labels.index(weft)),
                 weft,
                 verticalalignment="bottom",

--- a/src/cdsg_plot/qcdb_plot.py
+++ b/src/cdsg_plot/qcdb_plot.py
@@ -412,7 +412,7 @@ def valerr(
     ebuf = max(0.01, abs(0.02 * emax))
     plt.xlim([xmin - xbuf, xmax + xbuf])
     ax1.set_ylim([vmin - vbuf, vmax + vbuf])
-    plt.legend(fontsize="x-small", frameon=False)
+    plt.legend(fontsize="x-small") #, frameon=False)
     ax2.set_ylim([emin - ebuf, emax + ebuf])
 
     # save and show
@@ -1005,7 +1005,7 @@ def ternary(
             transparent=True,
             format=ext,
             bbox_inches="tight",
-            #frameon=False,
+            # frameon=False,
             dpi=450,
             edgecolor="none",
             pad_inches=0.0,
@@ -1291,7 +1291,7 @@ def liliowa(
             transparent=True,
             format=ext,
             bbox_inches="tight",
-            frameon=False,
+            # frameon=False,
             pad_inches=0.0,
         )
         files_saved[ext.lower()] = savefile
@@ -1344,6 +1344,7 @@ if __name__ == "__main__":
         title="MP2-CPa[]z",
         mae=[0.25, 0.5, 0.5, 0.3, 1.0],
         mape=[20.1, 25, 15, 5.5, 3.6],
+        view=False,
     )
 
     more_dats = [
@@ -1353,7 +1354,7 @@ if __name__ == "__main__":
         {"mc": "MP2-CP-adzagain", "data": [1.0, 0.8, 1.4, 1.6]},
     ]
 
-    bars(more_dats, title="asdf")
+    bars(more_dats, title="asdf", view=False)
 
     single_dats = [
         {"dbse": "HSG", "sys": "1", "data": [0.3508]},
@@ -1750,6 +1751,7 @@ if __name__ == "__main__":
         mae=1.21356003247,
         mape=24.6665886087,
         xlimit=4.0,
+        view=False,
     )
 
     lin_dats = [-0.5, -0.4, -0.3, 0, 0.5, 0.8, 5]
@@ -1762,7 +1764,7 @@ if __name__ == "__main__":
         "038PHE-041ILE-1",
         "199LEU-202GLU-1",
     ]
-    iowa(lin_dats, lin_labs, title="ttl", xlimit=0.5)
+    iowa(lin_dats, lin_labs, title="ttl", xlimit=0.5, view=False)
 
     figs = [
         0.22,
@@ -1791,9 +1793,9 @@ if __name__ == "__main__":
         0,
         0.69,
     ]
-    liliowa(figs, saveas="SSI-default-MP2-CP-aqz", xlimit=1.0)
+    liliowa(figs, saveas="SSI-default-MP2-CP-aqz", xlimit=1.0, view=False)
 
-    disthist(lin_dats)
+    disthist(lin_dats, view=False)
 
     valerrdata = [
         {
@@ -1956,4 +1958,5 @@ if __name__ == "__main__":
         xtitle="Rang",
         title="aggh",
         graphicsformat=["png"],
+        view=False,
     )

--- a/src/cdsg_plot/thread.py
+++ b/src/cdsg_plot/thread.py
@@ -1,7 +1,8 @@
 from cdsg_plot.qcdb_plot import threads as mpl_threads
 
 
-def plotly_threads(data, labels, color=None, title='', xlimit=4.0, mae=None, mape=None,
+def plotly_threads(data, labels, color=None, title='', xlimit=4.0, xlimitleft=None, xticks=None,
+    mae=None, mape=None,
     mousetext=None, mouselink=None, mouseimag=None, mousetitle=None, mousediv=None,
     labeled=True, view=True,
     saveas=None, relpath=False, graphicsformat=['pdf']):
@@ -31,7 +32,12 @@ def plotly_threads(data, labels, color=None, title='', xlimit=4.0, mae=None, map
     for weft in range(Nweft - 1):
         posnT.extend([positions[weft] - lenS - gapT, positions[weft + 1] + lenS + gapT, None])
     posnM = []
-    xticks = [-0.5 * xlimit, -0.25 * xlimit, 0.0, 0.25 * xlimit, 0.5 * xlimit]
+    if xlimitleft is None:
+        xlimitleft = -1 * xlimit
+    xrange = xlimit - xlimitleft
+    if xticks is None:
+        xticks = [xlimitleft + 0.25 * xrange, xlimitleft + 0.375 * xrange,
+                  xlimitleft + 0.5 * xrange, xlimitleft + 0.625 * xrange, xlimitleft + 0.75 * xrange]
 
     # initialize plot
     import plotly.graph_objects as go
@@ -43,14 +49,14 @@ def plotly_threads(data, labels, color=None, title='', xlimit=4.0, mae=None, map
         height=72 * Nweft * 0.8,
         margin=dict(b=36, l=7, r=7, t=34, pad=0),
         showlegend=False,
-        xaxis=dict(range=[-xlimit, xlimit], tickvals=xticks, zeroline=True, zerolinewidth=3),
+        xaxis=dict(range=[xlimitleft, xlimit], tickvals=xticks, zeroline=True, zerolinewidth=3),
         yaxis=dict(range=[-1 * Nweft - 1, 0], showticklabels=False),
     )
 
     # label plot and tiers
     annot = []
     annot.append(go.layout.Annotation(
-        x=-0.9 * xlimit,
+        x=xlimitleft + 0.05 * xrange,
         y=-0.25,
         align='left',
         #xanchor='left',
@@ -60,7 +66,7 @@ def plotly_threads(data, labels, color=None, title='', xlimit=4.0, mae=None, map
     ))
     for weft in labels:
         annot.append(go.layout.Annotation(
-            x=-0.9 * xlimit,
+            x=xlimitleft + 0.05 * xrange,
             y=-(1.0 + labels.index(weft)),
             xref="x",
             yref="y",


### PR DESCRIPTION
* for both mpl and plotly threads routines,
  - [x] adds `xlimitleft` argument so one can have non-symmetric plot range
  - [x] add `xticks` argument so one can set explicit tick marks
  - [x] alters color logic so that per-rxn color isn't always interpreted as sapt fraction
* turned off viewing, so `PYTHONPATH=. python cdsg_plot/qcdb_plot.py` doesn't hang. view saved files afterwards instead of during run.